### PR TITLE
Add biocViews keyword to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,16 @@ Suggests:
     knitr,
     rmarkdown
 VignetteBuilder: knitr
-Imports: Rcpp (>= 0.11.0), L1pack, Biobase, nnls, reshape, xbioc, cowplot, ggplot2, pheatmap
+Imports: 
+    Rcpp (>= 0.11.0),
+    L1pack,
+    Biobase,
+    nnls,
+    reshape,
+    xbioc,
+    cowplot,
+    ggplot2,
+    pheatmap
+biocViews:
 LinkingTo: Rcpp
 Depends: R (>= 3.0.1)


### PR DESCRIPTION
Installation with `install_github` fails with 

```
ERROR: dependencies ‘Biobase’, ‘xbioc’ are not available for package ‘SCDC’
```

Adding the `biocViews` keyword to the DESCRIPTION should fix that, since it tells remotes/devtools to also search Bioconductor.