### PR TITLE
Update ENSEMBLE.R

### DIFF
--- a/R/ENSEMBLE.R
+++ b/R/ENSEMBLE.R
@@ -101,7 +101,7 @@ SCDC_ENSEMBLE <- function(bulk.eset, sc.eset.list = NULL, ct.varname, sample,
   message("Searching ENSEMBLE weight by LAD -- Minimizing mAD of Y measurement")
   w_lad <-NA
   dt <- data.frame(y = yv, y.list)
-  fitlad <- L1pack::lad(y~.-1, data = dt, method = c("BR", "EM"))
+  fitlad <- L1pack::lad(y~.-1, data = dt, method = "BR")
   w_lad <- fitlad$coefficients
   w_lad[w_lad <0] <- 0
   w_lad <- w_lad/sum(w_lad)


### PR DESCRIPTION
If both methods (BR and EM) are present when using the lad function, it will report an error:

Error in switch(method, BR = lad.fit.BR(x, y, tol), EM = lad.fit.EM(x,  : 
  EXPR must be a length 1 vector

If we only use one of the methods, it will work fine. I tested both methods using the bulk RNA-seq in the tutorial, and it seems that the results are similar. So, I think going with the default will solve the problem.